### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: React App CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/StefRuseva88/github-actions-workflow/security/code-scanning/1](https://github.com/StefRuseva88/github-actions-workflow/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. For this workflow, which performs basic CI tasks (installing dependencies, building, linting, and testing), the minimal required permission is `contents: read`. This ensures the workflow can access the repository's contents without granting unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field (line 4) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
